### PR TITLE
Feat/wb2 850 Add id option and dismiss/remove function to toast

### DIFF
--- a/packages/react/src/hooks/useToast/useToast.tsx
+++ b/packages/react/src/hooks/useToast/useToast.tsx
@@ -5,6 +5,7 @@ import toast, { ToastPosition } from "react-hot-toast";
 import Alert from "../../components/Alert/Alert";
 
 export interface CustomToastOptions {
+  id?: string;
   isDismissible?: boolean;
   position?: ToastPosition;
   duration?: number;
@@ -25,6 +26,7 @@ export default function useToast() {
           {message}
         </Alert>,
         {
+          id: options?.id,
           duration: options?.duration,
           position: options?.position ?? DEFAULT_POSITION,
         },
@@ -40,6 +42,7 @@ export default function useToast() {
           {message}
         </Alert>,
         {
+          id: options?.id,
           duration: options?.duration,
           position: options?.position ?? DEFAULT_POSITION,
         },
@@ -55,6 +58,7 @@ export default function useToast() {
           {message}
         </Alert>,
         {
+          id: options?.id,
           duration: options?.duration,
           position: options?.position ?? DEFAULT_POSITION,
         },
@@ -70,11 +74,14 @@ export default function useToast() {
           {message}
         </Alert>,
         {
+          id: options?.id,
           duration: options?.duration,
           position: options?.position ?? DEFAULT_POSITION,
         },
       ),
     loading: toast.loading,
+    dismiss: (id: string) => toast.dismiss(id),
+    remove: (id: string) => toast.remove(id),
   };
 
   return toasts;


### PR DESCRIPTION
# Description

Add id option and dismiss/remove function to toast.

When creating a toast, we can pass an `id` that will be used then to `dismiss` or `remove` the toast.

`dismiss` function will remove the toast after 1 second.

`remove` function will remove instantly the toast.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [X] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
