### PR TITLE
Feat/wb2 11: add Dropdown placement positions

### DIFF
--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -25,7 +25,15 @@ export interface DropdownProps {
   /**
    * Default placement with FloatingUI
    */
-  placement?: "bottom-end" | "bottom-start";
+  placement?:
+    | "bottom-end"
+    | "bottom-start"
+    | "left"
+    | "left-start"
+    | "left-end"
+    | "right"
+    | "right-start"
+    | "right-end";
   /**
    * Extra keydown handler for the Dropdown Trigger.
    * Useful for a11y keyboard navigation between a Dropdown element and other elements,


### PR DESCRIPTION
# Description

Add Dropdown floating-ui placement positions.

Needed right position for collaborative wall note actions menu. 

Added left position also in case we'll need in the future ^^

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
