### PR TITLE
fix(core): WB-2615, use behaviour service to search among resources

### DIFF
--- a/packages/react/src/core/useResourceSearch/useResourceSearch.ts
+++ b/packages/react/src/core/useResourceSearch/useResourceSearch.ts
@@ -23,11 +23,9 @@ import { useMockedData } from "../../utils";
  * `resourceApplications: Array<App>`
  * Resources-producing applications the user can use.
  *
- * `loadResources: (filters:GetContextParameters) => void`
+ * `loadResources: (filters:GetContextParameters) => Promise<ILinkedResource[]>`
  * A search method with filters.
  *
- * Note : until all applications are using the explorer main page,
- * only the first resource of the `filter.types` array will be considered while searching.
  */
 export const useResourceSearch = (appCode: App) => {
   // Needed for storybook to mock calls to backend
@@ -69,9 +67,8 @@ export const useResourceSearch = (appCode: App) => {
             }),
           )
         : await odeServices
-            .resource(appCode, resourceType)
-            .searchContext(filters)
-            .then((results) => results.resources);
+            .behaviour(appCode, resourceType)
+            .loadResources(filters);
 
       return payload;
     },

--- a/packages/react/src/multimedia/Linker/InternalLinker.tsx
+++ b/packages/react/src/multimedia/Linker/InternalLinker.tsx
@@ -150,7 +150,7 @@ const InternalLinker = ({
         selectResource(resource);
       } else {
         setSelectedDocuments(
-          selectedDocuments.filter((value, i) => i !== index),
+          selectedDocuments.filter((_value, i) => i !== index),
         );
       }
     },
@@ -279,7 +279,7 @@ const InternalLinker = ({
               ) >= 0;
             return (
               <LinkerCard
-                key={resource.assetId}
+                key={resource.path}
                 doc={resource}
                 isSelected={isSelected}
                 onClick={() => toggleResourceSelection(resource)}


### PR DESCRIPTION
# Description

Use the new `behaviour` service to display resources int the Linker.
See https://github.com/edificeio/edifice-ts-client/pull/32

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [X] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
