### PR TITLE
fix: #WB-2679 bbm visibility

### DIFF
--- a/packages/editor/src/components/Editor/Editor.tsx
+++ b/packages/editor/src/components/Editor/Editor.tsx
@@ -51,6 +51,10 @@ export interface EditorProps {
   toolbar?: "full" | "none";
   /** Display with or without a border */
   variant?: "outline" | "ghost";
+
+  /** Visibility of the content created
+   *  this will impact where the uploaded files will be upload and the availability of the public media files  */
+  visibility?: WorkspaceVisibility;
 }
 
 const Editor = forwardRef(
@@ -60,6 +64,7 @@ const Editor = forwardRef(
       mode = "read",
       toolbar = "full",
       variant = "outline",
+      visibility = "protected",
     }: EditorProps,
     ref: Ref<EditorRef>,
   ) => {
@@ -69,7 +74,7 @@ const Editor = forwardRef(
       useMediaLibraryModal(editor);
     const { toggle: toggleMathsModal, ...mathsModalHandlers } =
       useMathsModal(editor);
-    const imageModal = useImageModal(editor);
+    const imageModal = useImageModal(editor, "media-library", visibility);
     const linkToolbarHandlers = useLinkToolbar(editor, mediaLibraryModalRef);
     const speechSynthetisis = useSpeechSynthetisis(editor);
 
@@ -140,6 +145,7 @@ const Editor = forwardRef(
           {editable && (
             <MediaLibrary
               appCode={appCode}
+              visibility={visibility}
               ref={mediaLibraryModalRef}
               {...mediaLibraryModalHandlers}
             />

--- a/packages/editor/src/components/Editor/Editor.tsx
+++ b/packages/editor/src/components/Editor/Editor.tsx
@@ -4,6 +4,7 @@ import "@edifice-tiptap-extensions/extension-image";
 import { LoadingScreen, MediaLibrary, useOdeClient } from "@edifice-ui/react";
 import { EditorContent, Content, JSONContent } from "@tiptap/react";
 import clsx from "clsx";
+import { WorkspaceVisibility } from "edifice-ts-client";
 
 import {
   EditorToolbar,

--- a/packages/editor/src/hooks/useImageModal.ts
+++ b/packages/editor/src/hooks/useImageModal.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { useToggle, useWorkspaceFile } from "@edifice-ui/react";
 import { Editor } from "@tiptap/react";
+import { WorkspaceVisibility } from "edifice-ts-client";
 
 import { useImageSelection } from "./useImageSelection";
 
@@ -18,7 +19,11 @@ type EditedImage = { src: string; alt?: string; title?: string } | undefined;
  * `handleSave`: Success event handler,
  * }
  */
-export const useImageModal = (editor: Editor | null) => {
+export const useImageModal = (
+  editor: Editor | null,
+  application?: string,
+  visibility?: WorkspaceVisibility,
+) => {
   const [currentImage, setCurrentImage] = useState<EditedImage | undefined>(
     undefined,
   );
@@ -57,6 +62,8 @@ export const useImageModal = (editor: Editor | null) => {
       legend,
       alt,
       uri: currentImage?.src,
+      visibility,
+      application,
     });
     toggle();
     setAttributes({

--- a/packages/editor/src/hooks/useMediaLibraryModal.ts
+++ b/packages/editor/src/hooks/useMediaLibraryModal.ts
@@ -46,7 +46,9 @@ export const useMediaLibraryModal = (editor: Editor | null) => {
               ?.chain()
               .focus()
               .setNewImage({
-                src: `/workspace/document/${image._id}`,
+                src: `/workspace/${image.public ? "pub/" : ""}document/${
+                  image._id
+                }`,
                 alt: image.alt,
                 title: image.title,
               })
@@ -67,10 +69,10 @@ export const useMediaLibraryModal = (editor: Editor | null) => {
           // The setAudio() command does not auto-select the inserted audio.
           // => reset the cursor position after inserting
           const { from } = editor.state.selection;
-          sounds.reverse().forEach((sound) => {
+          sounds.reverse().forEach((sound: WorkspaceElement) => {
             editor?.commands.setAudio(
               sound._id || "",
-              `/workspace/document/${sound._id}`,
+              `/workspace/${sound.public ? "pub/" : ""}document/${sound._id}`,
             );
             editor?.commands.setTextSelection(from);
           });
@@ -93,7 +95,7 @@ export const useMediaLibraryModal = (editor: Editor | null) => {
             videos.reverse().forEach((video) => {
               editor?.commands.setVideo(
                 video._id || "",
-                `/workspace/document/${video._id}`,
+                `/workspace/${video.public ? "pub/" : ""}document/${video._id}`,
                 true,
               );
               editor?.commands.setTextSelection(from);
@@ -105,9 +107,10 @@ export const useMediaLibraryModal = (editor: Editor | null) => {
         case "attachment": {
           let innerHtml = "";
           for (let i = 0; i < result.length; i++) {
-            innerHtml += `<a href="/workspace/document/${
-              (result as WorkspaceElement[])[i]._id
-            }">${(result as WorkspaceElement[])[i].name}
+            const link = (result as WorkspaceElement[])[i];
+            innerHtml += `<a href="/workspace/${
+              link.public ? "pub/" : ""
+            }document/${link._id}">${link.name}
             </a>`;
           }
           const richContent = `<div class="attachments">

--- a/packages/react/src/core/useUploadFiles/useUploadFiles.ts
+++ b/packages/react/src/core/useUploadFiles/useUploadFiles.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 
-import { WorkspaceElement } from "edifice-ts-client";
+import { WorkspaceElement, WorkspaceVisibility } from "edifice-ts-client";
 
 import { useDropzoneContext } from "../../components/Dropzone/DropzoneContext";
 import { Status } from "../../types";
@@ -8,8 +8,12 @@ import { useWorkspaceFile } from "../useWorkspaceFile";
 
 const useUploadFiles = ({
   handleOnChange,
+  visibility,
+  application,
 }: {
   handleOnChange: (uploadedFiles: WorkspaceElement[]) => void;
+  visibility?: WorkspaceVisibility;
+  application?: string;
 }) => {
   const [uploadedFiles, setUploadedFiles] = useState<WorkspaceElement[]>([]);
   const [status, setStatus] = useState<Record<string, Status>>({});
@@ -45,7 +49,7 @@ const useUploadFiles = ({
     }));
 
     try {
-      const resource = await create(file);
+      const resource = await create(file, { application, visibility });
 
       setStatus((prevStatus) => ({
         ...prevStatus,
@@ -113,7 +117,9 @@ const useUploadFiles = ({
   }
   function getUrl(resource?: WorkspaceElement, timestamp?: boolean) {
     return resource
-      ? `/workspace/document/${resource?._id}?timestamp=${
+      ? `/workspace/${
+          resource.public ? "pub/" : ""
+        }document/${resource?._id}?timestamp=${
           timestamp ? new Date().getTime() : ""
         }`
       : "";

--- a/packages/react/src/core/useWorkspaceFile/useWorkspaceFile.ts
+++ b/packages/react/src/core/useWorkspaceFile/useWorkspaceFile.ts
@@ -1,4 +1,8 @@
-import { WorkspaceElement, odeServices } from "edifice-ts-client";
+import {
+  WorkspaceElement,
+  WorkspaceVisibility,
+  odeServices,
+} from "edifice-ts-client";
 
 const useWorkspaceFile = () => {
   /**
@@ -20,6 +24,7 @@ const useWorkspaceFile = () => {
     legend,
     parentId,
     application,
+    visibility,
   }: {
     blob: Blob;
     uri?: string;
@@ -27,23 +32,32 @@ const useWorkspaceFile = () => {
     legend?: string;
     application?: string;
     parentId?: string;
+    visibility?: WorkspaceVisibility;
   }) => {
     const regex = /\/workspace\/document\/([0-9a-fA-F-]+)/;
     const matches = (uri ?? "").match(regex);
     if (matches && matches.length === 2) {
       const uuid = matches[1];
-      await odeServices.workspace().updateFile(uuid, blob, { alt, legend });
-      return `/workspace/document/${uuid}`;
+      const file: WorkspaceElement = await odeServices
+        .workspace()
+        .updateFile(uuid, blob, { alt, legend });
+      return `/workspace/${file.public ? "pub/" : ""}document/${uuid}`;
     } else {
       const res = await odeServices
         .workspace()
-        .saveFile(blob, { application, parentId });
-      return `/workspace/document/${res._id}`;
+        .saveFile(blob, { application, parentId, visibility });
+      return `/workspace/${res.public ? "pub/" : ""}document/${res._id}`;
     }
   };
   // const get = () => {}
-  const create = async (file: File) => {
-    return await odeServices.workspace().saveFile(file);
+  const create = async (
+    file: File,
+    params?: {
+      visibility?: WorkspaceVisibility;
+      application?: string | undefined;
+    },
+  ) => {
+    return await odeServices.workspace().saveFile(file, params);
   };
 
   // const put = () => {}

--- a/packages/react/src/multimedia/MediaLibrary/MediaLibrary.tsx
+++ b/packages/react/src/multimedia/MediaLibrary/MediaLibrary.tsx
@@ -403,10 +403,13 @@ const MediaLibrary = forwardRef(
     const handleOnSuccess = useCallback(() => {
       const triggerSuccess = async (result: MediaLibraryResult) => {
         // Copy WorkspaceElement from shared/owner folder to protected/public folder
-        if (result instanceof Array) {
+        if (
+          result instanceof Array &&
+          ["protected", "public"].findIndex((v) => v === visibility) >= 0
+        ) {
           result = await odeServices
             .workspace()
-            .transferDocuments(result, "media-library", visibility);
+            .transferDocuments(result, appCode ?? "media-library", visibility);
         }
         onSuccess(result);
       };

--- a/packages/react/src/multimedia/MediaLibrary/MediaLibrary.tsx
+++ b/packages/react/src/multimedia/MediaLibrary/MediaLibrary.tsx
@@ -18,7 +18,11 @@ import {
   Smartphone,
   Code,
 } from "@edifice-ui/icons";
-import { WorkspaceElement } from "edifice-ts-client";
+import {
+  WorkspaceElement,
+  WorkspaceVisibility,
+  odeServices,
+} from "edifice-ts-client";
 import { useTranslation } from "react-i18next";
 
 import { InnerTabs } from "./innertabs";
@@ -151,6 +155,12 @@ export type MediaLibraryResult =
 export interface MediaLibraryProps {
   /** Application Code (example: "blog"). */
   appCode: string;
+
+  /**
+   * Visibility of the uploaded files
+   */
+  visibility?: WorkspaceVisibility;
+
   multiple?: boolean;
   /**
    * Called when the user validates the modal (Add button).
@@ -175,7 +185,14 @@ export interface MediaLibraryProps {
 //---------------------------------------------------
 const MediaLibrary = forwardRef(
   (
-    { appCode, multiple, onSuccess, onCancel, onTabChange }: MediaLibraryProps,
+    {
+      appCode,
+      visibility,
+      multiple,
+      onSuccess,
+      onCancel,
+      onTabChange,
+    }: MediaLibraryProps,
     ref: Ref<MediaLibraryRef>,
   ) => {
     // Local ref will be merged with forwardRef in useImperativeHandle() below
@@ -384,15 +401,26 @@ const MediaLibrary = forwardRef(
     };
 
     const handleOnSuccess = useCallback(() => {
+      const triggerSuccess = async (result: MediaLibraryResult) => {
+        // Copy WorkspaceElement from shared/owner folder to protected/public folder
+        if (result instanceof Array) {
+          result = await odeServices
+            .workspace()
+            .transferDocuments(result, "media-library", visibility);
+        }
+        onSuccess(result);
+      };
+
       if (onSuccessAction) {
+        // First execute the pre-success action, then trigger the onSuccess callback.
         onSuccessAction().then((result) => {
-          onSuccess(result);
+          triggerSuccess(result);
         });
       } else if (result) {
-        onSuccess(result);
+        triggerSuccess(result);
       }
       resetState();
-    }, [onSuccess, onSuccessAction, result]);
+    }, [onSuccessAction, result, onSuccess, visibility]);
 
     const handleOnCancel = () => {
       onCancel(cancellable);
@@ -403,6 +431,7 @@ const MediaLibrary = forwardRef(
       <MediaLibraryContext.Provider
         value={{
           appCode,
+          visibility,
           multiple,
           type,
           setResultCounter,

--- a/packages/react/src/multimedia/MediaLibrary/MediaLibraryContext.tsx
+++ b/packages/react/src/multimedia/MediaLibrary/MediaLibraryContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
 
-import { WorkspaceElement } from "edifice-ts-client";
+import { WorkspaceElement, WorkspaceVisibility } from "edifice-ts-client";
 
 import {
   MediaLibraryType,
@@ -13,6 +13,11 @@ export const MediaLibraryContext = createContext<{
    * Application code (example: "blog")
    */
   appCode: string;
+
+  /**
+   * Visibility of the uploaded files
+   */
+  visibility?: WorkspaceVisibility;
 
   multiple?: boolean;
 

--- a/packages/react/src/multimedia/MediaLibrary/innertabs/Upload.tsx
+++ b/packages/react/src/multimedia/MediaLibrary/innertabs/Upload.tsx
@@ -26,8 +26,14 @@ const acceptedTypes = (type: MediaLibraryType) => {
 };
 
 export const Upload = () => {
-  const { type, multiple, setResult, setResultCounter, addCancellable } =
-    useMediaLibraryContext();
+  const {
+    type,
+    visibility,
+    multiple,
+    setResult,
+    setResultCounter,
+    addCancellable,
+  } = useMediaLibraryContext();
 
   const handleOnFilesChange = (uploadedFiles: WorkspaceElement[]) => {
     if (uploadedFiles.length) {
@@ -45,7 +51,10 @@ export const Upload = () => {
   return (
     <div className="py-8 flex-grow-1">
       <Dropzone multiple={multiple} accept={acceptedTypes(type ?? "embedder")}>
-        <UploadFiles onFilesChange={handleOnFilesChange} />
+        <UploadFiles
+          onFilesChange={handleOnFilesChange}
+          visibility={visibility}
+        />
       </Dropzone>
     </div>
   );

--- a/packages/react/src/multimedia/MediaLibrary/innertabs/Workspace.tsx
+++ b/packages/react/src/multimedia/MediaLibrary/innertabs/Workspace.tsx
@@ -4,7 +4,8 @@ import { Workspace as Component } from "../../Workspace";
 import { useMediaLibraryContext } from "../MediaLibraryContext";
 
 export const Workspace = () => {
-  const { type, setResultCounter, setResult } = useMediaLibraryContext();
+  const { type, setResultCounter, setResult, visibility } =
+    useMediaLibraryContext();
 
   function getDocumentRoleFilter(): Role | Role[] | null {
     switch (type) {
@@ -33,6 +34,8 @@ export const Workspace = () => {
       roles={getDocumentRoleFilter()}
       onSelect={handleSelect}
       className="border rounded overflow-y-auto"
+      defaultFolder={visibility}
+      showPublicFolder={visibility === "public"}
     ></Component>
   );
 };

--- a/packages/react/src/multimedia/UploadFiles/UploadFiles.tsx
+++ b/packages/react/src/multimedia/UploadFiles/UploadFiles.tsx
@@ -1,4 +1,4 @@
-import { WorkspaceElement } from "edifice-ts-client";
+import { WorkspaceElement, WorkspaceVisibility } from "edifice-ts-client";
 
 import { UploadCard } from "../../components";
 import useUploadFiles from "../../core/useUploadFiles/useUploadFiles";
@@ -7,8 +7,10 @@ import ImageEditor from "../ImageEditor/components/ImageEditor";
 
 const Upload = ({
   onFilesChange,
+  visibility = "protected",
 }: {
   onFilesChange: (uploadedFiles: WorkspaceElement[]) => void;
+  visibility?: WorkspaceVisibility;
 }) => {
   const {
     files,
@@ -20,7 +22,11 @@ const Upload = ({
     editingImage,
     setEditingImage,
     getUrl,
-  } = useUploadFiles({ handleOnChange: onFilesChange });
+  } = useUploadFiles({
+    handleOnChange: onFilesChange,
+    application: "media-lirary",
+    visibility,
+  });
 
   return (
     <>


### PR DESCRIPTION
# Description

Fix issue with the import/select documents in multimedia library depending on the visibility.

When importing document we need to import it in the protected folder or public depending on the vibility we need.

When adding a document already existing in or workspace we need to transfer it to the correction place.

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [x] Core
- [ ] Icons
- [x] Hooks
- [x] Editor

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
