### PR TITLE
feat: #WB2-1588, add focus prop to Editor component

### DIFF
--- a/packages/editor/src/components/Editor/Editor.tsx
+++ b/packages/editor/src/components/Editor/Editor.tsx
@@ -2,7 +2,12 @@ import { Suspense, lazy, forwardRef, useImperativeHandle, Ref } from "react";
 
 import "@edifice-tiptap-extensions/extension-image";
 import { LoadingScreen, MediaLibrary, useOdeClient } from "@edifice-ui/react";
-import { EditorContent, Content, JSONContent } from "@tiptap/react";
+import {
+  EditorContent,
+  Content,
+  JSONContent,
+  FocusPosition,
+} from "@tiptap/react";
 import clsx from "clsx";
 
 import {
@@ -50,6 +55,8 @@ export interface EditorProps {
   toolbar?: "full" | "none";
   /** Display with or without a border */
   variant?: "outline" | "ghost";
+  /** Set focus position to the editor */
+  focus?: FocusPosition;
 }
 
 const Editor = forwardRef(
@@ -59,11 +66,16 @@ const Editor = forwardRef(
       mode = "read",
       toolbar = "full",
       variant = "outline",
+      focus = null,
     }: EditorProps,
     ref: Ref<EditorRef>,
   ) => {
     const { appCode } = useOdeClient();
-    const { editor, editable } = useTipTapEditor(mode === "edit", content);
+    const { editor, editable } = useTipTapEditor(
+      mode === "edit",
+      content,
+      focus,
+    );
     const { ref: mediaLibraryModalRef, ...mediaLibraryModalHandlers } =
       useMediaLibraryModal(editor);
     const { toggle: toggleMathsModal, ...mathsModalHandlers } =

--- a/packages/editor/src/hooks/useTipTapEditor.ts
+++ b/packages/editor/src/hooks/useTipTapEditor.ts
@@ -27,7 +27,7 @@ import TextAlign from "@tiptap/extension-text-align";
 import TextStyle from "@tiptap/extension-text-style";
 import Typography from "@tiptap/extension-typography";
 import Underline from "@tiptap/extension-underline";
-import { Content, useEditor } from "@tiptap/react";
+import { Content, FocusPosition, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { Mathematics } from "@tiptap-pro/extension-mathematics";
 
@@ -49,8 +49,13 @@ import {
  *
  * @param isEditable truthy if the editor content should be editable
  * @param content default rich content
+ * @param focus set focus position to the editor
  */
-export const useTipTapEditor = (editable: boolean, content: Content) => {
+export const useTipTapEditor = (
+  editable: boolean,
+  content: Content,
+  focus: FocusPosition,
+) => {
   const { currentLanguage } = useOdeClient();
 
   const editor = useEditor({
@@ -115,6 +120,10 @@ export const useTipTapEditor = (editable: boolean, content: Content) => {
     editor?.commands.setContent(content);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [content]);
+
+  useEffect(() => {
+    focus && editor?.commands.focus(focus);
+  }, [editor, focus, editable]);
 
   return { editor, editable };
 };


### PR DESCRIPTION
# Description

Add a `focus` prop to Editor component to set focus on Editor.

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
