### PR TITLE
fix: #WB-2566, add onContentChange to listen changement in editor

### DIFF
--- a/packages/editor/src/components/Editor/Editor.tsx
+++ b/packages/editor/src/components/Editor/Editor.tsx
@@ -58,6 +58,8 @@ export interface EditorProps {
   visibility?: WorkspaceVisibility;
   /** Editor placeholder content */
   placeholder?: string;
+  /** Function to listen if content change */
+  onContentChange?: ((content: string) => void) | undefined;
 }
 
 const Editor = forwardRef(
@@ -69,6 +71,7 @@ const Editor = forwardRef(
       variant = "outline",
       visibility = "protected",
       placeholder,
+      onContentChange,
     }: EditorProps,
     ref: Ref<EditorRef>,
   ) => {
@@ -77,6 +80,7 @@ const Editor = forwardRef(
       mode === "edit",
       content,
       placeholder,
+      onContentChange,
     );
     const { ref: mediaLibraryModalRef, ...mediaLibraryModalHandlers } =
       useMediaLibraryModal(editor);

--- a/packages/editor/src/components/Editor/Editor.tsx
+++ b/packages/editor/src/components/Editor/Editor.tsx
@@ -59,7 +59,7 @@ export interface EditorProps {
   /** Editor placeholder content */
   placeholder?: string;
   /** Function to listen if content change */
-  onContentChange?: ((content: string) => void) | undefined;
+  onContentChange?: ({ editor }: { editor: any }) => void;
 }
 
 const Editor = forwardRef(

--- a/packages/editor/src/hooks/useTipTapEditor.ts
+++ b/packages/editor/src/hooks/useTipTapEditor.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
 
 // Import TipTap module overloaded typings (custom commands)
 import "@edifice-tiptap-extensions/extension-audio";
@@ -15,7 +15,6 @@ import { SpeechRecognition } from "@edifice-tiptap-extensions/extension-speechre
 import { SpeechSynthesis } from "@edifice-tiptap-extensions/extension-speechsynthesis";
 import { TableCell } from "@edifice-tiptap-extensions/extension-table-cell";
 import { useOdeClient } from "@edifice-ui/react";
-import { Editor } from "@tiptap/core";
 import Color from "@tiptap/extension-color";
 import Focus from "@tiptap/extension-focus";
 import FontFamily from "@tiptap/extension-font-family";
@@ -56,7 +55,7 @@ export const useTipTapEditor = (
   editable: boolean,
   content: Content,
   placeholder?: string,
-  onContentChange?: ((content: string) => void) | undefined,
+  onContentChange?: ({ editor }: { editor: any }) => void,
 ) => {
   const { currentLanguage } = useOdeClient();
   const { t } = useTranslation();
@@ -116,21 +115,8 @@ export const useTipTapEditor = (
       AttachmentNodeView(AttachmentRenderer),
     ],
     content,
+    onUpdate: onContentChange,
   });
-
-  const updateCallback = useCallback(
-    ({ editor }: { editor: Editor }) => {
-      onContentChange?.(editor?.getHTML());
-    },
-    [onContentChange],
-  );
-
-  useEffect(() => {
-    onContentChange
-      ? editor?.on("update", updateCallback)
-      : editor?.off("update", updateCallback);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onContentChange]);
 
   useEffect(() => {
     editor?.setEditable(editable);

--- a/packages/editor/src/hooks/useTipTapEditor.ts
+++ b/packages/editor/src/hooks/useTipTapEditor.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 
 // Import TipTap module overloaded typings (custom commands)
 import "@edifice-tiptap-extensions/extension-audio";
@@ -15,6 +15,7 @@ import { SpeechRecognition } from "@edifice-tiptap-extensions/extension-speechre
 import { SpeechSynthesis } from "@edifice-tiptap-extensions/extension-speechsynthesis";
 import { TableCell } from "@edifice-tiptap-extensions/extension-table-cell";
 import { useOdeClient } from "@edifice-ui/react";
+import { Editor } from "@tiptap/core";
 import Color from "@tiptap/extension-color";
 import Focus from "@tiptap/extension-focus";
 import FontFamily from "@tiptap/extension-font-family";
@@ -115,14 +116,21 @@ export const useTipTapEditor = (
       AttachmentNodeView(AttachmentRenderer),
     ],
     content,
-    onUpdate: ({ editor }) => {
-      const content = editor?.getHTML();
-
-      if (onContentChange) {
-        onContentChange(content);
-      }
-    },
   });
+
+  const updateCallback = useCallback(
+    ({ editor }: { editor: Editor }) => {
+      onContentChange?.(editor?.getHTML());
+    },
+    [onContentChange],
+  );
+
+  useEffect(() => {
+    onContentChange
+      ? editor?.on("update", updateCallback)
+      : editor?.off("update", updateCallback);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onContentChange]);
 
   useEffect(() => {
     editor?.setEditable(editable);

--- a/packages/editor/src/hooks/useTipTapEditor.ts
+++ b/packages/editor/src/hooks/useTipTapEditor.ts
@@ -55,6 +55,7 @@ export const useTipTapEditor = (
   editable: boolean,
   content: Content,
   placeholder?: string,
+  onContentChange?: ((content: string) => void) | undefined,
 ) => {
   const { currentLanguage } = useOdeClient();
   const { t } = useTranslation();
@@ -114,6 +115,13 @@ export const useTipTapEditor = (
       AttachmentNodeView(AttachmentRenderer),
     ],
     content,
+    onUpdate: ({ editor }) => {
+      const content = editor?.getHTML();
+
+      if (onContentChange) {
+        onContentChange(content);
+      }
+    },
   });
 
   useEffect(() => {


### PR DESCRIPTION
# Description

Ajout de onContentChange pour récupérer les changements du contenu de l'éditeur en direct 

Ticket : https://edifice-community.atlassian.net/browse/WB-2655

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [x] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
