### PR TITLE
fix: #WB-2753, show public documents in Workspace when public folder is selected on Workspace tab load

### DIFF
--- a/packages/react/src/multimedia/Workspace/Workspace.tsx
+++ b/packages/react/src/multimedia/Workspace/Workspace.tsx
@@ -259,7 +259,15 @@ const Workspace = ({
         : (a, b) => compare(b.modified, a.modified);
 
     setDocuments(() => list.sort(sortFunction));
-  }, [currentNode, ownerRoot, protectRoot, sharedRoot, searchTerm, sortOrder]);
+  }, [
+    currentNode,
+    ownerRoot,
+    protectRoot,
+    sharedRoot,
+    publicRoot,
+    searchTerm,
+    sortOrder,
+  ]);
 
   /** Load initial content, once */
   // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
# Description

Show public documents in Workspace when public folder is selected on Media Library 'Workspace tab' load

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
