### PR TITLE
fix: #WB-2799 keep image size

### DIFF
--- a/packages/react/src/multimedia/AudioRecorder/useAudioRecorder.tsx
+++ b/packages/react/src/multimedia/AudioRecorder/useAudioRecorder.tsx
@@ -467,7 +467,6 @@ export default function useAudioRecorder(
                 reject("Error while saving");
               }
             }
-            console.log(event);
           };
         });
       }

--- a/packages/react/src/multimedia/ImageEditor/effects/misc.ts
+++ b/packages/react/src/multimedia/ImageEditor/effects/misc.ts
@@ -144,6 +144,7 @@ export async function updateImage(
   // Resize the view in css to keep img quality
   autoResize(application, sprite);
 }
+
 /**
  * This function resize the sprite according to the container width
  *
@@ -181,7 +182,6 @@ export function autoResize(
   if (application.view?.style) {
     application.view.style.width = `${newWidth}px`;
     application.view.style.height = `${newHeight}px`;
-    console.log(application.view.style.width, application.view.style.height);
   }
 }
 
@@ -230,9 +230,13 @@ export function constraintSize(
 export function saveAsBlob(application: PIXI.Application): Promise<Blob> {
   return new Promise<Blob>((resolve, reject) => {
     if (application?.view?.toBlob) {
-      application.view.toBlob((blob) => {
-        blob ? resolve(blob) : reject("EXTRACT_FAILED");
-      });
+      application.view.toBlob(
+        (blob) => {
+          blob ? resolve(blob) : reject("EXTRACT_FAILED");
+        },
+        "image/jpeg",
+        0.5,
+      );
     } else {
       reject("EXTRACT_FAILED");
     }

--- a/packages/react/src/multimedia/ImageEditor/effects/misc.ts
+++ b/packages/react/src/multimedia/ImageEditor/effects/misc.ts
@@ -8,6 +8,9 @@ const MIN_WIDTH = 100;
 const MODAL_VERTICAL_PADDING = 450;
 const MODAL_HORIZONTAL_PADDING = 64;
 
+// Using canvas to download the image increase the file size so to keep the same we need to apply a quality
+const DEFAULT_QUALITY = 0.5;
+
 // Define the default name of the sprite in the PIXI.Application context
 export const DEFAULT_SPRITE_NAME = "image";
 
@@ -235,7 +238,7 @@ export function saveAsBlob(application: PIXI.Application): Promise<Blob> {
           blob ? resolve(blob) : reject("EXTRACT_FAILED");
         },
         "image/jpeg",
-        0.5,
+        DEFAULT_QUALITY,
       );
     } else {
       reject("EXTRACT_FAILED");


### PR DESCRIPTION
# Description

Using canvas to download image increase the file size. To keep the same size we need to apply decrease the blob quality before sending it to the server.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks
- [x] BBM

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
