### PR TITLE
fix(react): #WB-2793, add aria-labels to breadcrumb hyperlinks

### DIFF
--- a/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.tsx
@@ -31,7 +31,11 @@ const Breadcrumb = forwardRef(
           {name ? (
             <>
               <BreadcrumbItem>
-                <a href={app?.address} className="d-flex">
+                <a
+                  href={app?.address}
+                  className="d-flex"
+                  aria-label={t(app?.displayName)}
+                >
                   <AppIcon app={app} size="40" />
                 </a>
               </BreadcrumbItem>
@@ -50,7 +54,11 @@ const Breadcrumb = forwardRef(
             </>
           ) : (
             <BreadcrumbItem className="gap-12 d-flex align-items-center">
-              <a href={app?.address} className="d-flex">
+              <a
+                href={app?.address}
+                className="d-flex"
+                aria-label={t(app?.displayName)}
+              >
                 <AppIcon app={app} size="40" />
               </a>
               <Heading


### PR DESCRIPTION
# Description

Lors des tests d'accessibilité sur Blog, il est apparu que notre Breadcrumb affichait parfois des liens hypertexte sans `text node` ni `aria-label`s.
Le fix a consisté à ajouter les `aria-label`s manquants.

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
