### PR TITLE
fix(ui): #WB-2860 audio record on firefox

### DIFF
--- a/packages/react/ui/src/multimedia/AudioRecorder/useAudioRecorder.tsx
+++ b/packages/react/ui/src/multimedia/AudioRecorder/useAudioRecorder.tsx
@@ -100,7 +100,7 @@ export default function useAudioRecorder(
   const { t } = useTranslation();
 
   const BUFFER_SIZE: number = 128; // https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletProcessor
-  const DEFAULT_SAMPLE_RATE: number = 44100;
+  const DEFAULT_SAMPLE_RATE: number = 48000;
 
   // Init Web Socket to send audio chunks to backend
   useEffect(() => {

--- a/public/infra/public/js/audioEncoder.js
+++ b/public/infra/public/js/audioEncoder.js
@@ -36,7 +36,7 @@ function writeUTFBytes(view, offset, string){
 
 var encoder = {
 	options: {
-		sampleRate: 44100
+		sampleRate: 48000
 	}
 };
 


### PR DESCRIPTION
# Description

The issue was due to firefox not allowing AudioContext to override the sample rate. To correct we just have to set by default the sample rate to 48000 which is the default value.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks
- [x] Multimedia

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
