### PR TITLE
fix(ui): #WB-2841 focus on input trigger windows resize + focus

### DIFF
--- a/packages/react/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/react/ui/src/components/Tabs/Tabs.tsx
@@ -56,15 +56,24 @@ const Tabs = ({ defaultId, items, onChange, children }: TabsProps) => {
 
   useEffect(() => {
     function setTabPosition() {
-      const currentTabIndex = items.findIndex((item) => item.id === activeTab);
-      if (currentTabIndex === -1 && defaultId) {
-        setActiveTab(defaultId);
-      }
-      const currentTabRef = tabsRef.current[currentTabIndex];
-      if (currentTabRef) {
-        currentTabRef.focus();
-        setTabUnderlineLeft(currentTabRef?.offsetLeft ?? 0);
-        setTabUnderlineWidth(currentTabRef?.clientWidth ?? 0);
+      /**
+       * If the active element is not an input, then focus on the current tab.
+       * The focus on input element with a reponse device will cause the keyboard to be displayed and trigger the resize event.
+       * Which will cause the tab to be focused again and the keyboard to be closed. #WB-2841
+       */
+      if (document?.activeElement?.tagName !== "INPUT") {
+        const currentTabIndex = items.findIndex(
+          (item) => item.id === activeTab,
+        );
+        if (currentTabIndex === -1 && defaultId) {
+          setActiveTab(defaultId);
+        }
+        const currentTabRef = tabsRef.current[currentTabIndex];
+        if (currentTabRef) {
+          currentTabRef.focus();
+          setTabUnderlineLeft(currentTabRef?.offsetLeft ?? 0);
+          setTabUnderlineWidth(currentTabRef?.clientWidth ?? 0);
+        }
       }
     }
 


### PR DESCRIPTION
# Description

The issue is due to focusing an input while in responsive display is triggering the windows resize event. And we are listening it and changing the focus which will close the virtual keyboard.

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
