### PR TITLE
fix(ui): #WB-2828 responsive toaster block scrollbar

### DIFF
--- a/packages/react/ui/src/portal/Layout/Layout.tsx
+++ b/packages/react/ui/src/portal/Layout/Layout.tsx
@@ -57,8 +57,32 @@ const Layout = ({ children, headless = false, ...restProps }: LayoutProps) => {
 
   const renderToaster = (
     <Toaster
+      containerStyle={{
+        zIndex: 0,
+      }}
       toastOptions={{
         position: "top-right",
+        style: {},
+        success: {
+          style: {
+            zIndex: 9999,
+          },
+        },
+        error: {
+          style: {
+            zIndex: 9999,
+          },
+        },
+        loading: {
+          style: {
+            zIndex: 9999,
+          },
+        },
+        custom: {
+          style: {
+            zIndex: 9999,
+          },
+        },
       }}
     />
   );


### PR DESCRIPTION
# Description

In responsive mode when the keyboard is open the vertical scollbar is lock by the container div created by react-hot-toast. The fix is to decrease the z-index of the container.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks
- [x] Toaster

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
