### PR TITLE
fix(editor): #WB-2870, Linker cards should always display content text

### DIFF
--- a/packages/react/editor/src/components/Renderer/LinkerRenderer.tsx
+++ b/packages/react/editor/src/components/Renderer/LinkerRenderer.tsx
@@ -1,25 +1,26 @@
 import { MouseEventHandler } from "react";
 
 import { AppIcon, Badge, useOdeIcons } from "@edifice-ui/react";
+import { Node } from "@tiptap/pm/model";
 import { Editor, NodeViewWrapper } from "@tiptap/react";
 import clsx from "clsx";
 
 interface LinkerProps {
   selected: boolean;
   editor: Editor;
-  [x: string]: any;
+  node: Node;
 }
 
 const LinkerRenderer = ({ selected, ...props }: LinkerProps) => {
   const { getIconCode } = useOdeIcons();
-  const { editor } = props;
+  const { editor, node } = props;
   const {
     class: className,
     title,
     "data-app-prefix": appPrefix,
     href,
     target,
-  } = props.node.attrs;
+  } = node.attrs;
 
   const classes = clsx(
     "align-middle badge-linker c-pointer mx-4",
@@ -46,7 +47,7 @@ const LinkerRenderer = ({ selected, ...props }: LinkerProps) => {
         data-drag-handle
       >
         <AppIcon size="24" app={appCode} />
-        <span className="ms-8 text-truncate">{title}</span>
+        <span className="ms-8 text-truncate">{title || node.textContent}</span>
       </Badge>
     </NodeViewWrapper>
   );


### PR DESCRIPTION
# Description

[Ticket WB-2870](https://edifice-community.atlassian.net/browse/WB-2870)

Les liens internes historiques contiennent parfois du texte customisé, à afficher (si aucun autre texte n'est disponible).

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks
- [X] Editor

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
