### PR TITLE
feat(ui): #WB-2858, sticky searchbar for the internal linker

### DIFF
--- a/packages/react/ui/src/multimedia/Linker/InternalLinker.tsx
+++ b/packages/react/ui/src/multimedia/Linker/InternalLinker.tsx
@@ -238,8 +238,8 @@ const InternalLinker = ({
   }, [resources]);
 
   return (
-    <div className="internal-linker flex-grow-1 w-100 rounded border gap-0 overflow-auto">
-      <div className="search d-flex bg-light rounded-top border-bottom">
+    <div className="d-flex flex-column flex-fill overflow-hidden">
+      <div className="search d-flex bg-light rounded-top border border-bottom-0">
         <div className="flex-shrink-1 px-8 py-12 border-end">
           <Dropdown overflow>
             <Dropdown.Trigger
@@ -284,44 +284,46 @@ const InternalLinker = ({
         </div>
       </div>
 
-      {selectedApplication && resources && resources.length > 0 && (
-        <div>
-          {resources.map((resource) => {
-            const isSelected =
-              selectedDocuments.findIndex(
-                (doc) => doc.assetId === resource.assetId,
-              ) >= 0;
-            return (
-              <LinkerCard
-                key={resource.path}
-                doc={resource}
-                isSelected={isSelected}
-                onClick={() => toggleResourceSelection(resource)}
-              />
-            );
-          })}
-        </div>
-      )}
+      <div className="internal-linker flex-grow-1 w-100 rounded-bottom border gap-0 overflow-auto">
+        {selectedApplication && resources && resources.length > 0 && (
+          <div>
+            {resources.map((resource) => {
+              const isSelected =
+                selectedDocuments.findIndex(
+                  (doc) => doc.assetId === resource.assetId,
+                ) >= 0;
+              return (
+                <LinkerCard
+                  key={resource.path}
+                  doc={resource}
+                  isSelected={isSelected}
+                  onClick={() => toggleResourceSelection(resource)}
+                />
+              );
+            })}
+          </div>
+        )}
 
-      {selectedApplication && resources && resources.length <= 0 && (
-        <div className="d-flex justify-content-center mt-16">
-          <EmptyScreen
-            imageSrc={`${imagePath}/${theme?.bootstrapVersion}/illu-empty-search-${selectedApplication.application}.svg`}
-            text={t("bbm.linker.int.notfound")}
-            className="mt-16"
-          />
-        </div>
-      )}
+        {selectedApplication && resources && resources.length <= 0 && (
+          <div className="d-flex justify-content-center mt-16">
+            <EmptyScreen
+              imageSrc={`${imagePath}/${theme?.bootstrapVersion}/illu-empty-search-${selectedApplication.application}.svg`}
+              text={t("bbm.linker.int.notfound")}
+              className="mt-16"
+            />
+          </div>
+        )}
 
-      {!selectedApplication && (
-        <div className="d-flex justify-content-center mt-32">
-          <EmptyScreen
-            imageSrc={`${imagePath}/${theme?.bootstrapVersion}/illu-empty-search.svg`}
-            text={t("bbm.linker.int.empty")}
-            className="mt-32"
-          />
-        </div>
-      )}
+        {!selectedApplication && (
+          <div className="d-flex justify-content-center mt-32">
+            <EmptyScreen
+              imageSrc={`${imagePath}/${theme?.bootstrapVersion}/illu-empty-search.svg`}
+              text={t("bbm.linker.int.empty")}
+              className="mt-32"
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/react/ui/src/multimedia/Linker/InternalLinker.tsx
+++ b/packages/react/ui/src/multimedia/Linker/InternalLinker.tsx
@@ -147,22 +147,25 @@ const InternalLinker = ({
   // Select a resource.
   const selectResource = useCallback(
     (resource: ILinkedResource) => {
-      if (!multiple) {
-        setSelectedDocuments([resource]);
-      } else {
+      if (multiple) {
+        // Add this resource to the previous selected ones.
         setSelectedDocuments((previousState) => [...previousState, resource]);
+      } else {
+        // Replace previous selection by this resource.
+        setSelectedDocuments([resource]);
       }
     },
-    [setSelectedDocuments],
+    [setSelectedDocuments, multiple],
   );
 
   // Handle [de-]selection of a resource by the user.
   const toggleResourceSelection = useCallback(
     (resource: ILinkedResource) => {
       const index = getSelectedResourceIndex(resource.assetId);
-      if (index < 0 || multiple) {
+      if (index < 0) {
         selectResource(resource);
       } else {
+        // De-select resource (clicked twice)
         setSelectedDocuments(
           selectedDocuments.filter((_value, i) => i !== index),
         );


### PR DESCRIPTION
# Description

[Ticket WB-2858](https://edifice-community.atlassian.net/browse/WB-2858)

Le linker interne possède une barre de recherche, mais elle défile avec le contenu puis disparait lorsque il y a trop de contenus à afficher.
Cette PR la rend "sticky" => elle ne défile plus avec le contenu.

De plus, elle corrige un bug sur la sélection de contenus multiples, probablement issu d'une fusion de branche mal traitée.


## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
