### PR TITLE
fix: #WB2-1659, fix toolbar a11y keyboard navigation with disabled elements

### DIFF
--- a/packages/react/ui/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/react/ui/src/components/Toolbar/Toolbar.stories.tsx
@@ -41,6 +41,7 @@ const meta: Meta<typeof Toolbar> = {
         props: {
           icon: <RecordVideo />,
           onClick: () => console.log("on click"),
+          disabled: true,
         },
       },
       {
@@ -60,6 +61,7 @@ const meta: Meta<typeof Toolbar> = {
         props: {
           icon: <Write />,
           onClick: () => console.log("on click"),
+          disabled: true,
         },
       },
       {


### PR DESCRIPTION
# Description

Fix toolbar a11y keyboard navigation with disabled elements:

If the first toolbar element was disabled then toolbar focus using Tab key was not working, so I set the toolbar focus on first non disabled element and set the navigation through non disabled elements.

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
