### PR TITLE
Fix/WB-2443_old-image-compatibility

### DIFF
--- a/packages/tiptap/extensions/extension-image/src/CustomImage.ts
+++ b/packages/tiptap/extensions/extension-image/src/CustomImage.ts
@@ -69,19 +69,32 @@ export const CustomImage = Image.extend<CustomImageOptions>({
         parseHTML: (element) => element.getAttribute("title"),
       },
       width: {
-        default: "350",
         renderHTML: (attributes) => {
-          return {
-            width: parseInt(attributes.width),
-          };
+          if (
+            attributes.width !== null &&
+            attributes.width !== undefined &&
+            !Number.isNaN(attributes.width)
+          ) {
+            return {
+              width: parseInt(attributes.width),
+            };
+          }
+          return {};
         },
         parseHTML: (element) => element.getAttribute("width"),
       },
       height: {
         renderHTML: (attributes) => {
-          return {
-            height: parseInt(attributes.height),
-          };
+          if (
+            attributes.height !== null &&
+            attributes.height !== undefined &&
+            !Number.isNaN(attributes.height)
+          ) {
+            return {
+              height: parseInt(attributes.height),
+            };
+          }
+          return {};
         },
         parseHTML: (element) => element.getAttribute("height"),
       },
@@ -114,6 +127,9 @@ export const CustomImage = Image.extend<CustomImageOptions>({
             if (el.parentElement.style?.width) {
               attr["width"] = el.parentElement.style.width;
             }
+          }
+          if (el.style?.width) {
+            attr["width"] = el.style.width;
           }
 
           // Check old content smiley


### PR DESCRIPTION
# Description

Remove default width causing issue with old format images.
+ Add check on width style for old format compatibility.

## Which Package changed?

Please check the name of the package you changed

- [x] Editor

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
