### PR TITLE
fix: #WB-2445, hide rafter if treeview children array is empty and fold/unfold tree when clicking on item

### DIFF
--- a/packages/react/ui/src/components/TreeView/TreeItem.tsx
+++ b/packages/react/ui/src/components/TreeView/TreeItem.tsx
@@ -137,7 +137,7 @@ const TreeItem = (props: TreeItemProps) => {
             onKeyDown={handleItemFoldUnfoldKeyDown}
             aria-label={t("foldUnfold")}
           >
-            {Array.isArray(children) && !expanded && (
+            {Array.isArray(children) && !!children.length && !expanded && (
               <RafterRight
                 title={t("foldUnfold")}
                 width={rafterSize}
@@ -145,7 +145,7 @@ const TreeItem = (props: TreeItemProps) => {
               />
             )}
 
-            {Array.isArray(children) && expanded && (
+            {Array.isArray(children) && !!children.length && expanded && (
               <RafterDown
                 title={t("foldUnfold")}
                 width={rafterSize}

--- a/packages/react/ui/src/components/TreeView/hooks/useTreeItemEvents.tsx
+++ b/packages/react/ui/src/components/TreeView/hooks/useTreeItemEvents.tsx
@@ -12,6 +12,7 @@ export default function useTreeItemEvents(
   const handleItemClick = (event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault();
     onItemSelect?.(nodeId);
+    itemFoldUnfold();
     event.stopPropagation();
   };
 
@@ -19,6 +20,7 @@ export default function useTreeItemEvents(
     if (event.code === "Enter" || event.code === "Space") {
       event.preventDefault();
       onItemSelect?.(nodeId);
+      itemFoldUnfold();
       event.stopPropagation();
     }
   };


### PR DESCRIPTION
# Description

- Hide rafter if treeview children array is empty
- Fold/unfold tree when clicking on item

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
