### PR TITLE
fix(ui): #WB-2862, use a default thumbnail size of 120x120 pixels

### DIFF
--- a/packages/client/src/ts/resources/behaviours/WorkspaceBehaviour.ts
+++ b/packages/client/src/ts/resources/behaviours/WorkspaceBehaviour.ts
@@ -42,7 +42,7 @@ export class WorkspaceBehaviour extends AbstractBehaviourService {
             const icon =
               data.metadata["content-type"] &&
               data.metadata["content-type"].indexOf("image") !== -1
-                ? `/workspace/document/${data._id}?thumbnail=150x150`
+                ? `/workspace/document/${data._id}?thumbnail=120x120`
                 : "/img/icons/unknown-large.png";
             return this.dataToResource({
               title: data.name,

--- a/packages/client/src/ts/workspace/Service.ts
+++ b/packages/client/src/ts/workspace/Service.ts
@@ -262,17 +262,20 @@ export class WorkspaceService {
     width: number = 0,
     height: number = 0,
   ) {
+    const thumbnailSize =
+      width > 0 || height > 0 ? `${width}x${height}` : "120x120";
+
     if (typeof doc === "string") {
       if (doc.includes("data:image") || doc.includes("thumbnail")) {
         return doc;
       }
-      return `${doc}${doc.includes("?") ? "&" : "?"}thumbnail=${width}x${height}`;
+      return `${doc}${doc.includes("?") ? "&" : "?"}thumbnail=${thumbnailSize}`;
     } else {
       const urlPrefix = `/workspace/${doc.public ? "pub/" : ""}document/${doc._id}?thumbnail=`;
       const thumbnails = doc.thumbnails;
 
-      // Videos may have only 1 thumbnail, and the backend cannot create new ones at the moment.
       if (doc.metadata?.["content-type"]?.includes("video")) {
+        // Videos may have only 1 thumbnail, and the backend cannot create new ones at the moment.
         // Return the first thumbnail, or `null` if none is available.
         const firstThumbnail =
           thumbnails && Object.keys(thumbnails).length > 0
@@ -280,11 +283,8 @@ export class WorkspaceService {
             : null;
         return firstThumbnail ? urlPrefix + firstThumbnail : null;
       } else {
-        // Return a thumbnail with requested sizes, or default to 150x150
-        return (
-          urlPrefix +
-          (width > 0 || height > 0 ? `${width}x${height}` : "150x150")
-        );
+        // Return a thumbnail with requested sizes, or default to 120x120
+        return urlPrefix + thumbnailSize;
       }
     }
   }


### PR DESCRIPTION
# Description

Revert from the 150x150 thumbnail sizes used in Medialibrary.

## Which Package changed?

Please check the name of the package you changed

- [X] Client
- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
