### PR TITLE
fix: #WB-3007, add sort function to keep order select image

### DIFF
--- a/packages/react/ui/src/core/useUploadFiles/useUploadFiles.ts
+++ b/packages/react/ui/src/core/useUploadFiles/useUploadFiles.ts
@@ -54,8 +54,26 @@ const useUploadFiles = ({
     });
   }, [files, getUploadStatus, uploadFile]);
 
+  const sortUploadedFiles = (
+    filesArray: File[],
+    uploadedFilesArray: WorkspaceElement[],
+  ) => {
+    const orderMap = filesArray.reduce(
+      (acc: any, item: File, index: number) => {
+        acc[item.name] = index;
+        return acc;
+      },
+      {},
+    );
+    return uploadedFilesArray.sort(
+      (a: WorkspaceElement, b: WorkspaceElement) =>
+        orderMap[a.name] - orderMap[b.name],
+    );
+  };
+
   useEffect(() => {
-    handleOnChange(uploadedFiles);
+    const sortedUploadedFiles = sortUploadedFiles(files, uploadedFiles);
+    handleOnChange(sortedUploadedFiles);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uploadedFiles]);
 


### PR DESCRIPTION
# Description

Ajout d'une fonction de tri pour récupérer l'ordre de sélection depuis le navigateur.

Ticket : https://edifice-community.atlassian.net/browse/WB-3007

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [x] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
