### PR TITLE
fix: #WB-3015, allow adding more videos to upload, removing them...

### DIFF
--- a/packages/client/src/ts/video/Service.ts
+++ b/packages/client/src/ts/video/Service.ts
@@ -31,12 +31,14 @@ export class VideoService {
       APP.VIDEO,
     );
     return {
-      maxWeight: publicConf["max-videosize-mbytes"] || VideoService.MAX_WEIGHT,
+      maxWeight:
+        publicConf?.["max-videosize-mbytes"] ?? VideoService.MAX_WEIGHT,
       maxDuration:
-        publicConf["max-videoduration-minutes"] || VideoService.MAX_DURATION,
-      acceptVideoUploadExtensions: publicConf[
-        "accept-videoupload-extensions"
-      ].map((ext) => ext.toUpperCase()),
+        publicConf?.["max-videoduration-minutes"] ?? VideoService.MAX_DURATION,
+      acceptVideoUploadExtensions:
+        publicConf?.["accept-videoupload-extensions"]?.map((ext) =>
+          ext.toUpperCase(),
+        ) ?? [],
     };
   }
 

--- a/packages/react/editor/src/components/Editor/Editor.tsx
+++ b/packages/react/editor/src/components/Editor/Editor.tsx
@@ -180,6 +180,7 @@ const Editor = forwardRef(
             <MediaLibrary
               appCode={appCode}
               visibility={visibility}
+              multiple={true}
               ref={mediaLibraryModalRef}
               {...mediaLibraryModalHandlers}
             />

--- a/packages/react/ui/src/components/Dropzone/Dropzone.tsx
+++ b/packages/react/ui/src/components/Dropzone/Dropzone.tsx
@@ -10,6 +10,7 @@ import useDropzone from "../../hooks/useDropzone/useDropzone";
 
 interface DropzoneProps {
   className?: string;
+  /** See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept#unique_file_type_specifiers */
   accept?: string[];
   multiple?: boolean;
   handle?: boolean;

--- a/packages/react/ui/src/core/useUploadFiles/useUploadFiles.ts
+++ b/packages/react/ui/src/core/useUploadFiles/useUploadFiles.ts
@@ -35,9 +35,9 @@ const useUploadFiles = ({
     files.forEach((file) => {
       const status = getUploadStatus(file);
       /* Do not upload :
-         * the same file twice.
+         - the same file twice.
            To upload it again, reset its previous status first.
-         * more than 5 files at once.
+         - more than 5 files at once.
       */
       if (status || numUploads >= MAX_UPLOADS_AT_ONCE) return;
 
@@ -78,19 +78,21 @@ const useUploadFiles = ({
   }, [uploadedFiles]);
 
   async function removeFile(file: File) {
+    // Check if this file was successfully uploaded.
     const resource = uploadedFiles.find(
       (uploadedFile) => uploadedFile.name === file.name,
     );
 
+    // Remove the corresponding resource from `uploadedFiles`
     if (resource) {
       await remove(resource);
       clearUploadStatus(file);
       setUploadedFiles((prevFiles: WorkspaceElement[]) => {
         return prevFiles.filter((prevFile) => prevFile.name !== resource?.name);
       });
-
-      deleteFile(file);
     }
+    // Remove the file from `files`
+    deleteFile(file);
   }
 
   async function updateImage({

--- a/packages/react/ui/src/multimedia/MediaLibrary/MediaLibrary.tsx
+++ b/packages/react/ui/src/multimedia/MediaLibrary/MediaLibrary.tsx
@@ -156,11 +156,10 @@ export interface MediaLibraryProps {
   /** Application Code (example: "blog"). */
   appCode: string;
 
-  /**
-   * Visibility of the uploaded files "protected" | "public" | "external".
-   */
+  /** Visibility of the uploaded files "protected" | "public" | "external". */
   visibility: WorkspaceVisibility;
 
+  /** Allow selecting / uploading multiple files at once ? */
   multiple?: boolean;
   /**
    * Called when the user validates the modal (Add button).

--- a/packages/react/ui/src/multimedia/MediaLibrary/MediaLibraryContext.tsx
+++ b/packages/react/ui/src/multimedia/MediaLibrary/MediaLibraryContext.tsx
@@ -9,30 +9,23 @@ import {
 } from "./MediaLibrary";
 
 export const MediaLibraryContext = createContext<{
-  /**
-   * Application code (example: "blog")
-   */
+  /** Application code (example: "blog") */
   appCode: string;
 
-  /**
-   * Visibility of the uploaded files
-   */
+  /** Visibility of the uploaded files. */
   visibility?: WorkspaceVisibility;
 
+  /** Allow selecting / uploading multiple files at once ? */
   multiple?: boolean;
 
-  /**
-   * Type of rss to search for
-   */
+  /** Type of resource to search for. */
   type: MediaLibraryType | null;
 
-  /**
-   * Set the counter in the success button label
-   */
+  /** Set the counter in the success button label. */
   setResultCounter: (count?: number) => void;
 
   /**
-   * Set a innertab-specific callback which gets the result when success button is clicked
+   * Set a innertab-specific callback which gets the result when success button is clicked.
    */
   setResult: (result?: MediaLibraryResult) => void;
 
@@ -47,9 +40,7 @@ export const MediaLibraryContext = createContext<{
    */
   setVisibleTab: (tab: AvailableTab) => void;
 
-  /**
-   * Allow an innertab to switch type of the media library.
-   */
+  /** Allow an innertab to switch type of the media library. */
   switchType: (type: MediaLibraryType) => void;
 
   /**

--- a/packages/react/ui/src/multimedia/UploadFiles/UploadFiles.tsx
+++ b/packages/react/ui/src/multimedia/UploadFiles/UploadFiles.tsx
@@ -2,7 +2,7 @@ import { WorkspaceElement, WorkspaceVisibility } from "edifice-ts-client";
 
 import { useEffect, useRef } from "react";
 import { UploadCard } from "../../components";
-import useUploadFiles from "../../core/useUploadFiles/useUploadFiles";
+import { useUploadFiles } from "../../core";
 import { customSize } from "../../utils/fileSize";
 import { ImageEditor } from "../ImageEditor";
 


### PR DESCRIPTION
... when failed, fix console errors

# Description

> [Ticket WB-3015](https://edifice-community.atlassian.net/browse/WB-3015)

J'en ai profité pour :
- améliorer des commentaires flous,
- corriger un log vu en console en cas de mauvais paramétrage de l'appli video,
- appliquer un cache de données aux confs publiques des applis, qui ne sont jamais mises à jour sauf en cas de redéploiement.

Le but était de pouvoir récupérer `/video/public/conf` depuis certains hooks en lien avec la vidéo, en 1 seul appel au backend.
Mais la conf historique sur les extensions vidéos acceptables n'est plus forcément utilisée (ce n'est pas très clair dans les specs), du coup les hooks identifiés n'ont finalement pas été retouchés, mais j'ai préféré laisser l'optimisation sur la conf publique tout de même.

## Which Package changed?

Please check the name of the package you changed

- [X] Client
- [X] Components
- [X] Core
- [ ] Icons
- [X] Hooks
- [X] Multimedia

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
