### PR TITLE
feat(ui): #WB2-1742, add shareOptions to make ShareModal compatible with any apps

### DIFF
--- a/packages/react/ui/src/common/ShareModal/ShareBookmark.tsx
+++ b/packages/react/ui/src/common/ShareModal/ShareBookmark.tsx
@@ -3,8 +3,8 @@ import { Ref } from "react";
 import { Save } from "@edifice-ui/icons";
 import { useTranslation } from "react-i18next";
 
+import { Button, FormControl } from "../../components";
 import { BookmarkProps } from "./hooks/useShareBookmark";
-import { FormControl, Button } from "../..";
 
 export const ShareBookmark = ({
   bookmark,

--- a/packages/react/ui/src/common/ShareModal/ShareBookmarkLine.tsx
+++ b/packages/react/ui/src/common/ShareModal/ShareBookmarkLine.tsx
@@ -1,4 +1,4 @@
-import { Bookmark, RafterDown, Close } from "@edifice-ui/icons";
+import { Bookmark, Close, RafterDown } from "@edifice-ui/icons";
 import {
   ShareRight,
   ShareRightAction,
@@ -7,9 +7,9 @@ import {
 } from "edifice-ts-client";
 import { useTranslation } from "react-i18next";
 
+import { Avatar, Button, Checkbox, IconButton } from "../../components";
 import { hasRight } from "./utils/hasRight";
 import { showShareRightLine } from "./utils/showShareRightLine";
-import { Avatar, Button, Checkbox, IconButton } from "../..";
 
 export const ShareBookmarkLine = ({
   shareRights,

--- a/packages/react/ui/src/common/ShareModal/apps/ShareBlog.tsx
+++ b/packages/react/ui/src/common/ShareModal/apps/ShareBlog.tsx
@@ -1,21 +1,23 @@
-import { useState, ChangeEvent } from "react";
+import { ChangeEvent, useState } from "react";
 
 import { UseMutationResult } from "@tanstack/react-query";
 import {
   BlogResource,
   BlogUpdate,
+  ID,
   UpdateParameters,
   UpdateResult,
   odeServices,
 } from "edifice-ts-client";
 import { useTranslation } from "react-i18next";
-
-import { useOdeClient, Heading, Radio } from "../../..";
+import { Heading, Radio } from "../../../components";
+import { useOdeClient } from "../../../core";
+import { useResource } from "../../../core/useResource";
 
 export type PublicationType = "RESTRAINT" | "IMMEDIATE" | undefined;
 
 export interface ShareBlogProps {
-  resource: BlogResource;
+  resourceId: ID;
   updateResource?: UseMutationResult<
     UpdateResult,
     unknown,
@@ -25,11 +27,13 @@ export interface ShareBlogProps {
 }
 
 export default function ShareBlog({
-  resource,
+  resourceId,
   updateResource,
 }: ShareBlogProps) {
   const { appCode } = useOdeClient();
   const { t } = useTranslation(appCode);
+
+  const resource = useResource("blog", resourceId) as BlogResource;
 
   const publishType = resource && resource["publish-type"];
 

--- a/packages/react/ui/src/common/ShareModal/hooks/useSearch.tsx
+++ b/packages/react/ui/src/common/ShareModal/hooks/useSearch.tsx
@@ -1,20 +1,21 @@
 import { ChangeEvent, Dispatch, useEffect, useReducer } from "react";
 
 import { Bookmark } from "@edifice-ui/icons";
+
 import {
-  odeServices,
-  ShareRightAction,
   ShareRight,
-  IResource,
-  ShareSubject,
+  ShareRightAction,
   ShareRightWithVisibles,
+  ShareSubject,
+  odeServices,
 } from "edifice-ts-client";
 import { useTranslation } from "react-i18next";
 
-import { ShareAction } from "./useShare";
 import { OptionListItemType } from "../../../components";
 import { useIsAdml, useOdeClient } from "../../../core";
 import { useDebounce } from "../../../hooks";
+import { ShareOptions } from "../ShareModal";
+import { ShareAction } from "./useShare";
 
 type State = {
   searchInputValue: string;
@@ -69,11 +70,13 @@ const defaultActions: ShareRightAction[] = [
 ];
 
 export const useSearch = ({
-  resource,
+  resourceId,
+  resourceCreatorId,
   shareRights,
   shareDispatch,
 }: {
-  resource: IResource;
+  resourceId: ShareOptions["resourceCreatorId"];
+  resourceCreatorId: ShareOptions["resourceCreatorId"];
   shareRights: ShareRightWithVisibles;
   shareDispatch: Dispatch<ShareAction>;
 }) => {
@@ -103,7 +106,7 @@ export const useSearch = ({
   };
 
   const search = async (debouncedSearchInputValue: string) => {
-    if (!resource) return;
+    if (!resourceId) return;
 
     dispatch({
       type: "isSearching",
@@ -116,11 +119,7 @@ export const useSearch = ({
     ) {
       const resSearchShareSubjects = await odeServices
         .share()
-        .searchShareSubjects(
-          appCode,
-          resource.assetId,
-          debouncedSearchInputValue,
-        );
+        .searchShareSubjects(appCode, resourceId, debouncedSearchInputValue);
 
       dispatch({
         type: "addApiResult",
@@ -138,7 +137,7 @@ export const useSearch = ({
         // exclude owner from results
         .filter(
           (right: { type: string; id: any }) =>
-            !(right.type === "user" && right.id === resource?.creatorId),
+            !(right.type === "user" && right.id === resourceCreatorId),
         )
         .map(
           (searchResult: {

--- a/packages/react/ui/src/common/ShareModal/hooks/useShareBookmark.ts
+++ b/packages/react/ui/src/common/ShareModal/hooks/useShareBookmark.ts
@@ -3,8 +3,8 @@ import { Dispatch, useId, useRef, useState } from "react";
 import { ShareRightWithVisibles, odeServices } from "edifice-ts-client";
 import { useTranslation } from "react-i18next";
 
+import { useToast, useToggle } from "../../../hooks";
 import { ShareAction } from "./useShare";
-import { useToast, useToggle } from "../../..";
 
 interface UseShareBookmarkProps {
   shareRights: ShareRightWithVisibles;


### PR DESCRIPTION
# Description

https://edifice-community.atlassian.net/browse/WB2-1742

Add `shareOptions` props to make `ShareModal` self-sufficient. No more explorer call to share a resource.

`shareOptions` needs 3 informations:
- resourceId -> id of the resource aka `assetId`
- resourceCreatorId -> id of the user who created the resource
- resourceRights -> normalized rights `rights[]`

```
// e.g
const shareOptions = {
    resourceCreatorId: data?.owner.userId,
    resourceId: data?._id,
    resourceRights: data?.rights,
};
```

Only "ShareBlog" component gets its resource from explorer (because the application uses explorer and this component is used in the explorer application)

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [x] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
