### PR TITLE
fix: #WB-3106, cleaner handling of files upload

### DIFF
--- a/packages/react/ui/src/components/Dropzone/Dropzone.tsx
+++ b/packages/react/ui/src/components/Dropzone/Dropzone.tsx
@@ -6,7 +6,7 @@ import { DropzoneContext } from "./DropzoneContext";
 import DropzoneDrag from "./DropzoneDrag";
 import DropzoneFile from "./DropzoneFile";
 import DropzoneImport from "./DropzoneImport";
-import useDropzone from "../../hooks/useDropzone/useDropzone";
+import { useDropzone } from "../../hooks";
 
 interface DropzoneProps {
   className?: string;

--- a/packages/react/ui/src/components/ImagePicker/ImagePicker.tsx
+++ b/packages/react/ui/src/components/ImagePicker/ImagePicker.tsx
@@ -10,7 +10,7 @@ import { Delete, Edit } from "@edifice-ui/icons";
 import clsx from "clsx";
 import { IWebApp } from "edifice-ts-client";
 
-import useDropzone from "../../hooks/useDropzone/useDropzone";
+import { useDropzone } from "../../hooks";
 import { AppIcon } from "../AppIcon";
 import { Avatar } from "../Avatar";
 import { IconButton } from "../Button";

--- a/packages/react/ui/src/core/useUpload/useUpload.ts
+++ b/packages/react/ui/src/core/useUpload/useUpload.ts
@@ -135,10 +135,22 @@ const useUpload = (
     }
   };
 
+  function uploadAlternateFile(
+    original: File,
+    replacement: File,
+    metadata?: { duration: number },
+  ) {
+    // The original and its alternate must share the same virtual id.
+    getOrGenerateBlobId(replacement, getOrGenerateBlobId(original));
+    return uploadFile(replacement, metadata);
+  }
+
   return {
     getUploadStatus,
+    setUploadStatus,
     clearUploadStatus,
     uploadFile,
+    uploadAlternateFile,
     uploadBlob,
   };
 };

--- a/packages/react/ui/src/hooks/useDropzone/useDropzone.ts
+++ b/packages/react/ui/src/hooks/useDropzone/useDropzone.ts
@@ -6,9 +6,8 @@ const useDropzone = () => {
 
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const addFile = (file: File) => {
-    setFiles((prevFiles) => [...prevFiles, file]);
+    addFiles([file]);
   };
 
   const deleteFile = (file: File) => {
@@ -17,55 +16,66 @@ const useDropzone = () => {
     );
   };
 
+  const addFiles = (files: File[]) => {
+    setFiles((prevFiles) => [...prevFiles, ...files]);
+  };
+
   const cleanFiles = () => {
     setFiles([]);
   };
 
   const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
-
-    if (files)
-      [...files].forEach((file) => {
-        addFile(file);
-      });
+    if (files) addFiles([...files]);
   };
 
-  const handleDragging = (event: React.DragEvent<HTMLDivElement>) => {
+  const handleDragging = <T extends HTMLElement>(event: React.DragEvent<T>) => {
     event.preventDefault();
     event.stopPropagation();
     setDragging(true);
   };
 
-  const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+  const handleDragLeave = <T extends HTMLElement>(
+    event: React.DragEvent<T>,
+  ) => {
     event.preventDefault();
     event.stopPropagation();
     setDragging(false);
   };
 
-  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+  const handleDrop = <T extends HTMLElement>(event: React.DragEvent<T>) => {
     handleDragLeave(event);
     const files = event.dataTransfer?.files;
-
-    if (files)
-      [...files].forEach((file) => {
-        addFile(file);
-      });
-
-    if (inputRef?.current && files) {
-      inputRef.current.files = files;
+    if (files) {
+      addFiles([...files]);
+      if (inputRef?.current) {
+        inputRef.current.files = files;
+      }
     }
   };
 
   return {
+    /** Reference to an `input[type=file]` HTMLElement, null at first. */
     inputRef,
+    /** Read-only list of File·s  managed by this hook. */
     files,
+    /** Truthy when a drag event is triggered. */
     dragging,
+    /** Callback to attach to your drop zone (any HTMLElement). */
     handleDragging,
+    /** Callback to attach to your drop zone (any HTMLElement). */
     handleDragLeave,
+    /** Callback to attach to your drop zone (any HTMLElement). */
     handleDrop,
+    /** Use it to remove a file from the `files` list. */
     deleteFile,
+    /** Use it to add a file to the `files` list. */
     addFile,
+    /** Use it to add many files to the `files` list. */
+    addFiles,
+    /** Use it to empty the `files` list. */
     cleanFiles,
+    /** Callback to attach to your `input[type=file]` HTMLElement. */
     handleOnChange,
   };
 };


### PR DESCRIPTION
# Description

Le bug provenait d'appels async couplés à une logique imbriquée dans ces appels => au final, on faisait trop d'uploads async.
Le problème était donc percu aléatoirement et amplifié par le nombre important de render React (ça ressortait d'autant plus avec le resize d'images).

Pour corriger : 
* refacto de la logique de déclenchement d'uploads, pour la séparer de l'upload effectif.
* appel à `setUploadStatus(idle)` pour bien discriminer les fichiers qui vont être uploadés dans la logique citée plus haut.
* application réelle d'un garde-fou à 5 uploads en simultanée (c'était buggé).
* Isolation du hook `useUploadFiles` : il ne dépend plus de l'implémentation de `useUpload` et n'a plus besoin d'utiliser `getOrGenerateBlobId`
* ajout de commentaires
* réduction des render React en permettant d'importer X fichiers d'un coup, et plus l'un après l'autre.

Au final, c'est beaucoup plus rapide à l'exécution !

> [Ticket WB-3106](https://edifice-community.atlassian.net/browse/WB-3106)

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [X] Core
- [ ] Icons
- [X] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
