### PR TITLE
feat(ui): #WB-2036, compress to a valid format when resizing an image

### DIFF
--- a/packages/react/ui/src/components/Dropzone/Dropzone.tsx
+++ b/packages/react/ui/src/components/Dropzone/Dropzone.tsx
@@ -30,6 +30,7 @@ const Dropzone = ({
     files,
     addFile,
     deleteFile,
+    replaceFileAt,
     handleDragLeave,
     handleDragging,
     handleDrop,
@@ -51,8 +52,9 @@ const Dropzone = ({
       files,
       addFile,
       deleteFile,
+      replaceFileAt,
     }),
-    [addFile, deleteFile, files, inputRef],
+    [addFile, deleteFile, replaceFileAt, files, inputRef],
   );
 
   return (

--- a/packages/react/ui/src/components/Dropzone/DropzoneContext.tsx
+++ b/packages/react/ui/src/components/Dropzone/DropzoneContext.tsx
@@ -5,6 +5,7 @@ export interface DropzoneContextType {
   files: File[];
   addFile: (file: File) => void;
   deleteFile: (file: File) => void;
+  replaceFileAt: (index: number, file: File) => void;
 }
 
 export const DropzoneContext = createContext<DropzoneContextType | null>(null);

--- a/packages/react/ui/src/hooks/useDropzone/useDropzone.ts
+++ b/packages/react/ui/src/hooks/useDropzone/useDropzone.ts
@@ -22,6 +22,18 @@ const useDropzone = (props?: {
     );
   };
 
+  const replaceFileAt = (index: number, file: File) => {
+    setFiles((prevFiles) => {
+      if (0 <= index && index < prevFiles.length) {
+        const firstPart = prevFiles.slice(0, index);
+        const lastPart =
+          index === prevFiles.length - 1 ? [] : prevFiles.slice(index + 1);
+        return [...firstPart, file, ...lastPart];
+      }
+      return prevFiles;
+    });
+  };
+
   const applyInputFiltersOn = (files: File[]) => {
     let filteredFiles: File[] = files;
     if (inputRef.current?.accept) {
@@ -105,13 +117,15 @@ const useDropzone = (props?: {
     handleDragLeave,
     /** Callback to attach to your drop zone (any HTMLElement). */
     handleDrop,
-    /** Use it to remove a file from the `files` list. */
+    /** Replace a file in the `files` list. */
+    replaceFileAt,
+    /** Remove a file from the `files` list. */
     deleteFile,
-    /** Use it to add a file to the `files` list. */
+    /** Add a file to the `files` list. */
     addFile,
-    /** Use it to add many files to the `files` list. */
+    /** Add many files to the `files` list. */
     addFiles,
-    /** Use it to empty the `files` list. */
+    /** Empty the `files` list. */
     cleanFiles,
     /** Callback to attach to your `input[type=file]` HTMLElement. */
     handleOnChange,

--- a/packages/react/ui/src/hooks/useImageResizer/useImageResizer.ts
+++ b/packages/react/ui/src/hooks/useImageResizer/useImageResizer.ts
@@ -26,6 +26,19 @@ export default function useImageResizer() {
     return filenameParts.join(".") + "." + newExtension;
   };
 
+  function checkCompressFormat(
+    initialFormat: string,
+    desiredFormat: string | undefined,
+  ) {
+    if (!desiredFormat) {
+      initialFormat = initialFormat.trim().toLowerCase();
+      desiredFormat = ["png", "gif" /*, "jpg", "jpeg"*/].find(
+        (format) => format === initialFormat,
+      );
+    }
+    return desiredFormat ?? "jpeg";
+  }
+
   const resizeImage = (
     image: HTMLImageElement,
     fileName: string,
@@ -85,23 +98,28 @@ export default function useImageResizer() {
   /**
    * Resize and compress Image File
    * @param file  The image file to resize
+   * @param compressFormat  The format of the compressed image
    * @param maxWidth  The maximum width of the resized image
    * @param maxHeight   The maximum height of the resized image
-   * @param compressFormat  The format of the compressed image
    * @param quality   The quality of the compressed image
    * @returns   The resized image file
    */
   const resizeImageFile = async (
     file: File,
+    compressFormat?: string,
     maxWidth: number = 1440,
     maxHeight: number = 1440,
-    compressFormat: string = "jpeg",
     quality: number = 80,
   ): Promise<File> => {
     if (!file) throw Error("Image resizer: file not found!");
 
-    if (!file.type || !file.type.includes("image"))
+    if (!file.type || !file.type.startsWith("image/"))
       throw Error("Image resizer: the file given is not an image.");
+
+    compressFormat = checkCompressFormat(
+      file.type.split("image/")[1],
+      compressFormat,
+    );
 
     return new Promise((resolve) => {
       const image = new Image();


### PR DESCRIPTION
# Description

> [Ticket WB-2036](https://edifice-community.atlassian.net/browse/WB-2036)

Lors du resize d'image : 
- par défaut, conserve le format de l'image source si c'est _png_ ou _gif_, sinon passe en _jpeg_
- met à jour la liste des fichiers importés pour voir le type mime et le poids de l'image APRES resize

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [X] Core
- [ ] Icons
- [X] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
