### PR TITLE
fix: #WB-3014 rollback audio with preprocesseur for safari compatibility

### DIFF
--- a/packages/react/ui/src/multimedia/AudioRecorder/AudioRecorder.tsx
+++ b/packages/react/ui/src/multimedia/AudioRecorder/AudioRecorder.tsx
@@ -33,7 +33,7 @@ const AudioRecorder = forwardRef(
     const {
       recordState,
       playState,
-      recordtime,
+      recordTime,
       audioRef,
       audioNameRef,
       toolbarItems,
@@ -90,7 +90,7 @@ const AudioRecorder = forwardRef(
         <AudioRecorderTimer
           recordState={recordState}
           playState={playState}
-          recordTime={recordtime}
+          recordTime={recordTime}
           audioTime={audioTime}
           maxDuration={maxDuration}
         ></AudioRecorderTimer>


### PR DESCRIPTION
# Description

Roll back from MediaRecorder and use audio preprocessor for safari better compatibility with MP3 audio recorder.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks
- [x] Media library

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
