### PR TITLE
fix: #WB-3148 #WB-3159 embed code with p element + absolute position

### DIFF
--- a/packages/bootstrap/scss/components/tiptap/_iframe.scss
+++ b/packages/bootstrap/scss/components/tiptap/_iframe.scss
@@ -1,9 +1,7 @@
 .iframe-wrapper {
   position: relative;
-  padding-bottom: 56.25%;
-  padding-top: 0;
-  height: 0;
-  
+  min-height: 56vh;
+
   iframe {
     max-width: 100%;
   }

--- a/packages/bootstrap/scss/components/tiptap/_iframe.scss
+++ b/packages/bootstrap/scss/components/tiptap/_iframe.scss
@@ -1,6 +1,6 @@
 .iframe-wrapper {
   position: relative;
-  min-height: 56vh;
+  min-height: 56rem;
 
   iframe {
     max-width: 100%;

--- a/packages/react/ui/src/multimedia/MediaLibrary/innertabs/Iframe.tsx
+++ b/packages/react/ui/src/multimedia/MediaLibrary/innertabs/Iframe.tsx
@@ -5,6 +5,7 @@ export const Iframe = () => {
   const { setResult } = useMediaLibraryContext();
 
   const handleOnSuccess = (ressource?: string) => {
+    ressource = ressource?.replace(/<p /g, "<div ").replace(/\/p>/g, "/div>");
     setResult(ressource);
   };
 


### PR DESCRIPTION
# Description

WB-3148 issue was with tiptap not supporting `p` element in is custom node so we remplace them by a div
WB-3159 issue was with the position absolute in the embeded code one fix was introduce with the https://edifice-community.atlassian.net/browse/WB-3100 but it introduce some regression for other iframe. I replace the padding-bottom solution by a min-height.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks
- [x] Multimedia

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
