### PR TITLE
fix(editor): WB-3020, do not trigger an update content event when onl…

### DIFF
--- a/packages/react/editor/src/hooks/useTipTapEditor.ts
+++ b/packages/react/editor/src/hooks/useTipTapEditor.ts
@@ -127,7 +127,7 @@ export const useTipTapEditor = (
   });
 
   useEffect(() => {
-    editor?.setEditable(editable);
+    editor?.setEditable(editable, false); // Don't emit the update event, since content did not change.
   }, [editor, editable]);
 
   useEffect(() => {


### PR DESCRIPTION
…y editor's mode changes

# Description

Changer le mode read/update de l'éditeur ne doit pas émettre d'évènement "update" du contenu, car son contenu ne change effectivement pas.
S'il est émis, cela engendre un effet de bord potentiel lorsqu'on souhaite réinitialiser son contenu en même temps.

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
